### PR TITLE
Tweaks and comments

### DIFF
--- a/src/pd_density.jl
+++ b/src/pd_density.jl
@@ -1,6 +1,6 @@
 module pd_density
 
-using Images, Optim
+using Images, Optim    # Images is a pretty heavy dependency. Can you use a subset? I typically start with ImageCore and then add specific needed functonality.
 using FFTW, ZernikePolynomials, DSP
 
 struct InitialParam

--- a/src/pd_initialize.jl
+++ b/src/pd_initialize.jl
@@ -46,7 +46,7 @@ function zern_initial(H, rho, initial_param, imsz)
     kz = sqrt.(Complex.(coef^2 .- rho .^ 2))
     Hz = zeros(Complex{Float64}, imsz)
     for ix = 1:z
-        Hz[:, :, ix] = H .* cis.(2 * pi * zFrame[ix] .* kz)  # see comment in suppzern.jl. Is this change correct?
+        Hz[:, :, ix] = H .* cispi.(2 * zFrame[ix] .* kz)  # see comment in suppzern.jl. Is this change correct?
     end
     return Hz
 end

--- a/src/pd_initialize.jl
+++ b/src/pd_initialize.jl
@@ -2,8 +2,6 @@
 # Zernike initialization zern_initial()
 #
 
-debug = Ref{Any}()
-
 function pd_initial(NA, lambda, imsz)
     pupil = NA / lambda
 

--- a/src/pd_initialize.jl
+++ b/src/pd_initialize.jl
@@ -2,10 +2,13 @@
 # Zernike initialization zern_initial()
 #
 
+debug = Ref{Any}()
+
 function pd_initial(NA, lambda, imsz)
     pupil = NA / lambda
 
     H = zeros(imsz[1:2])
+    ## START BLOCK
     X = mapreduce(
         permutedims,
         vcat,
@@ -14,6 +17,16 @@ function pd_initial(NA, lambda, imsz)
 
     theta = atan.(X'X)
     rho = hypot.(X, X')
+    ## END BLOCK
+    # This block is not inferrable (it triggers red bars in ProfileView; left-click on the `construct_Zernmat` red bar
+    # and then type `descend_clicked()` on the command line, see the ProfileView and Cthulhu documentation).
+    # It also looks like an inefficient way to compute `rho` and `theta`, as it involves formation of a temporary `X` and
+    # further allocations from its usage. Would something like
+    #   xrng = yrng = blah   # you fill in `blah`
+    #   theta = [atan(y, x) for y in yrng, x in xrng]
+    #   rho = [hypot(x, y) for y in yrng, x in xrng]
+    # be correct, more efficient, and inferrable? Comprehensions, as this syntax is called, are almost always better than
+    # Matlab-esque ways of building such things.
     H = rho .^ 2 .<= pupil^2
 
     # pdk = zeros(size(H)..., length(zk))
@@ -35,7 +48,7 @@ function zern_initial(H, rho, initial_param, imsz)
     kz = sqrt.(Complex.(coef^2 .- rho .^ 2))
     Hz = zeros(Complex{Float64}, imsz)
     for ix = 1:z
-        Hz[:, :, ix] = H .* exp(im * 2 * pi * zFrame[ix] .* kz)
+        Hz[:, :, ix] = H .* exp.(im * 2 * pi * zFrame[ix] .* kz)  # see comment in suppzern.jl. Is this change correct?
     end
     return Hz
 end

--- a/src/pd_initialize.jl
+++ b/src/pd_initialize.jl
@@ -46,7 +46,7 @@ function zern_initial(H, rho, initial_param, imsz)
     kz = sqrt.(Complex.(coef^2 .- rho .^ 2))
     Hz = zeros(Complex{Float64}, imsz)
     for ix = 1:z
-        Hz[:, :, ix] = H .* exp.(im * 2 * pi * zFrame[ix] .* kz)  # see comment in suppzern.jl. Is this change correct?
+        Hz[:, :, ix] = H .* cis.(2 * pi * zFrame[ix] .* kz)  # see comment in suppzern.jl. Is this change correct?
     end
     return Hz
 end

--- a/src/suppzern.jl
+++ b/src/suppzern.jl
@@ -12,7 +12,7 @@ function ZernFT(Z, Hz, Zval, imsz)
     Hk = zeros(Complex{Float64}, imsz) # compute the pupil function
     hk = zeros(Complex{Float64}, imsz)
     for i = 1:imsz[3]
-        Hk[:, :, i] = Hz[:, :, i] .* cis.(phi)  # Critical! `cis(A)` computes the *matrix exponential* of `A`, not the elementwise exponential.
+        Hk[:, :, i] = Hz[:, :, i] .* cis.(phi)  # Critical! `exp(A)` computes the *matrix exponential* of `A`, not the elementwise exponential.
         hk[:, :, i] = ifft(Hk[:, :, i])              # See https://en.wikipedia.org/wiki/Matrix_exponential. I assume you want the elementwise exponential?
     end
     sk = hk .* conj(hk)

--- a/src/suppzern.jl
+++ b/src/suppzern.jl
@@ -12,7 +12,7 @@ function ZernFT(Z, Hz, Zval, imsz)
     Hk = zeros(Complex{Float64}, imsz) # compute the pupil function
     hk = zeros(Complex{Float64}, imsz)
     for i = 1:imsz[3]
-        Hk[:, :, i] = Hz[:, :, i] .* exp.(im * phi)  # Critical! `exp(A)` computes the *matrix exponential* of `A`, not the elementwise exponential.
+        Hk[:, :, i] = Hz[:, :, i] .* cis.(phi)  # Critical! `cis(A)` computes the *matrix exponential* of `A`, not the elementwise exponential.
         hk[:, :, i] = ifft(Hk[:, :, i])              # See https://en.wikipedia.org/wiki/Matrix_exponential. I assume you want the elementwise exponential?
     end
     sk = hk .* conj(hk)

--- a/src/suppzern.jl
+++ b/src/suppzern.jl
@@ -12,8 +12,8 @@ function ZernFT(Z, Hz, Zval, imsz)
     Hk = zeros(Complex{Float64}, imsz) # compute the pupil function
     hk = zeros(Complex{Float64}, imsz)
     for i = 1:imsz[3]
-        Hk[:, :, i] = Hz[:, :, i] .* exp(im * phi)
-        hk[:, :, i] = ifft(Hk[:, :, i])
+        Hk[:, :, i] = Hz[:, :, i] .* exp.(im * phi)  # Critical! `exp(A)` computes the *matrix exponential* of `A`, not the elementwise exponential.
+        hk[:, :, i] = ifft(Hk[:, :, i])              # See https://en.wikipedia.org/wiki/Matrix_exponential. I assume you want the elementwise exponential?
     end
     sk = hk .* conj(hk)
     Sk = zeros(Complex{Float64}, imsz)
@@ -54,7 +54,7 @@ function Zcoefs2phi(Zcoefs, Zval)
     #@show Zcoefs
     phi = zeros(size(Zval)[1:end-1])
     for i = 1:length(Zcoefs)
-        phi = phi + Zcoefs[i] * Zval[:, :, i]
+        phi .= phi .+ Zcoefs[i] .* Zval[:, :, i]
     end
     return phi
 end

--- a/src/zernike_fit.jl
+++ b/src/zernike_fit.jl
@@ -48,6 +48,8 @@ end
 
 function zernike_img_fit(img, initial_param::InitialParam; kwargs...)
     Hz, Zval = construct_Zernmat(img, initial_param)
+    # Since Hz and Zval are not inferrable, that means your definitions of `f` and `g!` are not inferrable either.
+    # That may be contributing to poor performance and test-timeouts (not yet sure).
 
     #g = zeros(1, Z_orders)
     f(Z) = zernikeloss(Z, img, Hz, Zval)
@@ -56,7 +58,7 @@ function zernike_img_fit(img, initial_param::InitialParam; kwargs...)
     params = zeros(1, initial_param.Z_orders)
 
     #result = optimize(f, g!, params, BFGS(), Optim.Options(; kwargs...))
-    result = optimize(f, params, BFGS(), Optim.Options(; kwargs...))
+    result = optimize(f, params, BFGS(), Optim.Options(; kwargs...))  # if you don't use your `g!`, you might want
     Optim.converged(result) || @warn "Optimization failed to converge"
     return result
 end


### PR DESCRIPTION
This may point out a significant bug that arose as a consequence of Matlab->Julia translation in handling of the exponential of a matrix: Julia's `exp(A)` corresponds to Matlab's `expm(A)` (note the `m`).

There are also some inference issues that may be hurting performance. You can find them by profiling the first call to `zernike_img_fit` in your tests.